### PR TITLE
Fix dependencies to work on new rubies without matrix bundled.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,24 @@
+PATH
+  remote: .
+  specs:
+    ruby_linear_regression (0.1.6)
+      csv
+      matrix
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    csv (3.3.0)
+    matrix (0.4.2)
+    minitest (5.25.4)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  minitest (~> 5.10, >= 5.10.2)
+  ruby_linear_regression!
+
+BUNDLED WITH
+   2.5.16

--- a/ruby_linear_regression.gemspec
+++ b/ruby_linear_regression.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = "ruby_linear_regression"
-  s.version     = "0.1.5"
-  s.date        = "2017-07-04"
+  s.version     = "0.1.6"
+  s.date        = "2024-09-04"
   s.summary     = "Linear regression implemented in Ruby."
   s.description = %q{An implementation of a linear regression machine learning algorithm implemented in Ruby.
   The library supports simple problems with one independent variable used to predict a dependent variable as well as multivariate problems with multiple independent variables to predict a dependent variable.
@@ -13,5 +13,7 @@ Gem::Specification.new do |s|
   s.homepage    =
     'https://github.com/daugaard/linear-regression'
   s.license       = 'MIT'
+  s.add_dependency 'csv'
+  s.add_dependency 'matrix'
   s.add_development_dependency 'minitest', '~> 5.10', '>= 5.10.2'
 end


### PR DESCRIPTION
Fixes https://github.com/daugaard/linear-regression/issues/4